### PR TITLE
Upped platform target version

### DIFF
--- a/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
+++ b/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>OneDrive-Cloud-Player</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
Microsoft states that the target platform version should be as recent as
possible to allow recent versions of Windows to run the application.

Target platform version went from `10.0.18362.0` to  `10.0.19041.0`.

https://docs.microsoft.com/en-us/windows/uwp/updates-and-versions/choose-a-uwp-version#choose-which-version-to-use-for-your-app 