### PR TITLE
Bump libvlcsharp version

### DIFF
--- a/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
+++ b/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
+++ b/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
@@ -257,7 +257,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="LibVLCSharp">
-      <Version>3.6.0</Version>
+      <Version>3.6.6</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph">
       <Version>3.19.0</Version>


### PR DESCRIPTION
The minimum target version has also been bumped to the required version since LibVLCSharp 3.6.2.