### PR TITLE
Fixes #71 crashing when leaving video early

### DIFF
--- a/OneDrive-Cloud-Player/ViewModels/VideoPlayerPageViewModel.cs
+++ b/OneDrive-Cloud-Player/ViewModels/VideoPlayerPageViewModel.cs
@@ -193,6 +193,18 @@ namespace OneDrive_Cloud_Player.ViewModels
             }
         }
 
+        private bool isBackBtnEnabled = false;
+
+        public bool IsBackBtnEnabled
+        {
+            get { return isBackBtnEnabled; }
+            set
+            {
+                isBackBtnEnabled = value;
+                OnPropertyChanged();
+            }
+        }
+
         /// <summary>
         /// Gets the media player
         /// </summary>
@@ -287,9 +299,7 @@ namespace OneDrive_Cloud_Player.ViewModels
             {
                 MediaPlayer.VolumeChanged -= UpdateInitialVolume;
                 MediaVolumeLevel = (int)App.Current.UserSettings.Values["MediaVolume"];
-
-                Debug.WriteLine(DateTime.Now.ToString("hh:mm:ss.fff") + ": UpdateInitialVolume: e.Volume: " + e.Volume);
-                Debug.WriteLine(DateTime.Now.ToString("hh:mm:ss.fff") + ": UpdateInitialVolume: Setting to: " + MediaVolumeLevel);
+                IsBackBtnEnabled = true;
             });
         }
 

--- a/OneDrive-Cloud-Player/Views/VideoPlayerPage.xaml
+++ b/OneDrive-Cloud-Player/Views/VideoPlayerPage.xaml
@@ -459,6 +459,7 @@
                         HorizontalAlignment="Center" VerticalAlignment="Center" 
                         Margin="0,0,0,0" Width="50" Height="50"
                         Command="{Binding StopMediaCommand}"
+                        IsEnabled="{Binding IsBackBtnEnabled}"
                         Background="Transparent">
                             <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xEB97;"/>
                         </Button>


### PR DESCRIPTION
Disables the back button until audio is initialized to prevent calling
the mediaplayer object after disposing causing a crash.