### PR TITLE
Replace broken store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <p>
      <i>A dedicated player to stream content directly from OneDrive.</i>
   </p>
-  <a href='//www.microsoft.com/store/apps/9NQ96Z5S1T3H?cid=storebadge&ocid=badge'><img src='https://developer.microsoft.com/en-us/store/badges/images/English_get-it-from-MS.png' alt='Arabic badge' style='width: 127px; height: 52px;'/></a>
+  <a href='https://www.microsoft.com/store/apps/9NQ96Z5S1T3H'><img src='https://developer.microsoft.com/en-us/store/badges/images/English_get-it-from-MS.png' alt='Arabic badge' style='width: 127px; height: 52px;'/></a>
 </div>
 
 ---


### PR DESCRIPTION
Now that the application is in the Microsoft Store, we can replace the broken link of the store badge with a working one.