### PR TITLE
Reenable x86; small .csproj fixes

### DIFF
--- a/OneDrive-Cloud-Player.sln
+++ b/OneDrive-Cloud-Player.sln
@@ -7,26 +7,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OneDrive-Cloud-Player", "On
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
-		Release|Any CPU = Release|Any CPU
 		Release|ARM = Release|ARM
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|ARM.ActiveCfg = Debug|ARM
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|ARM.Build.0 = Debug|ARM
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|ARM.Deploy.0 = Debug|ARM
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|x64.ActiveCfg = Debug|x64
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|x64.Build.0 = Debug|x64
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|x64.Deploy.0 = Debug|x64
-		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|ARM.ActiveCfg = Release|ARM
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|ARM.Build.0 = Release|ARM
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|ARM.Deploy.0 = Release|ARM

--- a/OneDrive-Cloud-Player.sln
+++ b/OneDrive-Cloud-Player.sln
@@ -9,8 +9,10 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|ARM = Release|ARM
 		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|ARM.ActiveCfg = Debug|ARM
@@ -19,12 +21,18 @@ Global
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|x64.ActiveCfg = Debug|x64
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|x64.Build.0 = Debug|x64
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|x64.Deploy.0 = Debug|x64
+		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|x86.ActiveCfg = Debug|x86
+		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|x86.Build.0 = Debug|x86
+		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Debug|x86.Deploy.0 = Debug|x86
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|ARM.ActiveCfg = Release|ARM
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|ARM.Build.0 = Release|ARM
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|ARM.Deploy.0 = Release|ARM
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|x64.ActiveCfg = Release|x64
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|x64.Build.0 = Release|x64
 		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|x64.Deploy.0 = Release|x64
+		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|x86.ActiveCfg = Release|x86
+		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|x86.Build.0 = Release|x86
+		{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}.Release|x86.Deploy.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
+++ b/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{A2003B0F-47A8-495C-ABD2-A7A38148C2D3}</ProjectGuid>
     <OutputType>AppContainerExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>

--- a/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
+++ b/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
@@ -281,7 +281,7 @@
       <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="VideoLAN.LibVLC.UWP">
-      <Version>3.3.1-81b133342b</Version>
+      <Version>3.3.2-ac996441</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup />

--- a/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
+++ b/OneDrive-Cloud-Player/OneDrive-Cloud-Player.csproj
@@ -23,7 +23,7 @@
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>x64</AppxBundlePlatforms>
+    <AppxBundlePlatforms>x86|x64|arm</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <GenerateTemporaryStoreCertificate>True</GenerateTemporaryStoreCertificate>
   </PropertyGroup>


### PR DESCRIPTION
- Reenable x86
- Disable Any CPU config
- Add all architectures to AppxBundle
- Set default architecture to x64